### PR TITLE
Add Support for PageRank Seed Vectors

### DIFF
--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -19,7 +19,10 @@ import {
 
 import {scoreByConstantTotal} from "./nodeScore";
 
-import {findStationaryDistribution} from "../core/attribution/markovChain";
+import {
+  findStationaryDistribution,
+  uniformDistribution,
+} from "../core/attribution/markovChain";
 
 export type {NodeDistribution} from "../core/attribution/graphToMarkovChain";
 export type {PagerankNodeDecomposition} from "./pagerankNodeDecomposition";
@@ -63,12 +66,20 @@ export async function pagerank(
     fullOptions.selfLoopWeight
   );
   const osmc = createOrderedSparseMarkovChain(connections);
-  const distributionResult = await findStationaryDistribution(osmc.chain, {
-    verbose: fullOptions.verbose,
-    convergenceThreshold: fullOptions.convergenceThreshold,
-    maxIterations: fullOptions.maxIterations,
-    yieldAfterMs: 30,
-  });
+  const alpha = 0;
+  const uniform = uniformDistribution(osmc.chain.length);
+  const distributionResult = await findStationaryDistribution(
+    osmc.chain,
+    uniform,
+    alpha,
+    uniform,
+    {
+      verbose: fullOptions.verbose,
+      convergenceThreshold: fullOptions.convergenceThreshold,
+      maxIterations: fullOptions.maxIterations,
+      yieldAfterMs: 30,
+    }
+  );
   const pi = distributionToNodeDistribution(
     osmc.nodeOrder,
     distributionResult.pi

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -6,7 +6,10 @@ import {
   createConnections,
   createOrderedSparseMarkovChain,
 } from "../core/attribution/graphToMarkovChain";
-import {findStationaryDistribution} from "../core/attribution/markovChain";
+import {
+  findStationaryDistribution,
+  uniformDistribution,
+} from "../core/attribution/markovChain";
 import {
   decompose,
   type PagerankNodeDecomposition,
@@ -131,12 +134,21 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
-      const distributionResult = await findStationaryDistribution(osmc.chain, {
-        verbose: false,
-        convergenceThreshold: 1e-6,
-        maxIterations: 255,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(osmc.chain.length);
+      const initialDistribution = uniformDistribution(osmc.chain.length);
+      const distributionResult = await findStationaryDistribution(
+        osmc.chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          verbose: false,
+          convergenceThreshold: 1e-6,
+          maxIterations: 255,
+          yieldAfterMs: 1,
+        }
+      );
       const pr = distributionToNodeDistribution(
         osmc.nodeOrder,
         distributionResult.pi
@@ -151,12 +163,21 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
-      const distributionResult = await findStationaryDistribution(osmc.chain, {
-        verbose: false,
-        convergenceThreshold: 1e-6,
-        maxIterations: 255,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(osmc.chain.length);
+      const initialDistribution = uniformDistribution(osmc.chain.length);
+      const distributionResult = await findStationaryDistribution(
+        osmc.chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          verbose: false,
+          convergenceThreshold: 1e-6,
+          maxIterations: 255,
+          yieldAfterMs: 1,
+        }
+      );
       const pr = distributionToNodeDistribution(
         osmc.nodeOrder,
         distributionResult.pi

--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -91,17 +91,47 @@ export function uniformDistribution(n: number): Distribution {
   return new Float64Array(n).fill(1 / n);
 }
 
+/**
+ * Distribution that is 1 at the indicator value and 0 elsewhere.
+ */
+export function indicatorDistribution(
+  size: number,
+  indicator: number
+): Distribution {
+  if (!isFinite(size) || size !== Math.floor(size) || size < 0) {
+    throw new Error("size: expected positive integer, but got: " + size);
+  }
+  if (
+    !isFinite(indicator) ||
+    indicator !== Math.floor(indicator) ||
+    indicator < 0
+  ) {
+    throw new Error(
+      "indicator: expected nonnegative integer, got: " + indicator
+    );
+  }
+  if (indicator >= size) {
+    throw new Error("indicator out of range");
+  }
+  const distribution = new Float64Array(size).fill(0);
+  distribution[indicator] = 1;
+
+  return distribution;
+}
+
 function sparseMarkovChainActionInto(
   chain: SparseMarkovChain,
+  seed: Distribution,
+  alpha: number,
   input: Distribution,
   output: Distribution
 ): void {
   chain.forEach(({neighbor, weight}, dst) => {
     const inDegree = neighbor.length; // (also `weight.length`)
-    let probability = 0;
+    let probability = alpha * seed[dst];
     for (let i = 0; i < inDegree; i++) {
       const src = neighbor[i];
-      probability += input[src] * weight[i];
+      probability += (1 - alpha) * input[src] * weight[i];
     }
     output[dst] = probability;
   });
@@ -109,10 +139,12 @@ function sparseMarkovChainActionInto(
 
 export function sparseMarkovChainAction(
   chain: SparseMarkovChain,
+  seed: Distribution,
+  alpha: number,
   pi: Distribution
 ): Distribution {
   const result = new Float64Array(pi.length);
-  sparseMarkovChainActionInto(chain, pi, result);
+  sparseMarkovChainActionInto(chain, seed, alpha, pi, result);
   return result;
 }
 
@@ -135,6 +167,9 @@ export function computeDelta(pi0: Distribution, pi1: Distribution) {
 
 function* findStationaryDistributionGenerator(
   chain: SparseMarkovChain,
+  seed: Distribution,
+  alpha: number,
+  initialDistribution: Distribution,
   options: {|
     +verbose: boolean,
     // A distribution is considered stationary if the action of the Markov
@@ -145,7 +180,7 @@ function* findStationaryDistributionGenerator(
     +maxIterations: number,
   |}
 ): Generator<void, StationaryDistributionResult, void> {
-  let pi = uniformDistribution(chain.length);
+  let pi = initialDistribution;
   let scratch = new Float64Array(pi.length);
 
   let nIterations = 0;
@@ -156,12 +191,12 @@ function* findStationaryDistributionGenerator(
       }
       // We need to do one more step so that we can compute the empirical convergence
       // delta for the returned distribution.
-      sparseMarkovChainActionInto(chain, pi, scratch);
+      sparseMarkovChainActionInto(chain, seed, alpha, pi, scratch);
       const convergenceDelta = computeDelta(pi, scratch);
       return {pi, convergenceDelta};
     }
     nIterations++;
-    sparseMarkovChainActionInto(chain, pi, scratch);
+    sparseMarkovChainActionInto(chain, seed, alpha, pi, scratch);
     // We compute the convergenceDelta between 'scratch' (the newest
     // distribution) and 'pi' (the distribution from the previous step). If the
     // delta is below threshold, then the distribution from the last step was
@@ -187,6 +222,9 @@ function* findStationaryDistributionGenerator(
 
 export function findStationaryDistribution(
   chain: SparseMarkovChain,
+  seed: Distribution,
+  alpha: number,
+  initialDistribution: Distribution,
   options: {|
     +verbose: boolean,
     +convergenceThreshold: number,
@@ -194,11 +232,17 @@ export function findStationaryDistribution(
     +yieldAfterMs: number,
   |}
 ): Promise<StationaryDistributionResult> {
-  let gen = findStationaryDistributionGenerator(chain, {
-    verbose: options.verbose,
-    convergenceThreshold: options.convergenceThreshold,
-    maxIterations: options.maxIterations,
-  });
+  let gen = findStationaryDistributionGenerator(
+    chain,
+    seed,
+    alpha,
+    initialDistribution,
+    {
+      verbose: options.verbose,
+      convergenceThreshold: options.convergenceThreshold,
+      maxIterations: options.maxIterations,
+    }
+  );
   return new Promise((resolve, _unused_reject) => {
     const {yieldAfterMs} = options;
     const tick = () => {

--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -98,7 +98,7 @@ export function indicatorDistribution(
   size: number,
   indicator: number
 ): Distribution {
-  if (!isFinite(size) || size !== Math.floor(size) || size < 0) {
+  if (!isFinite(size) || size !== Math.floor(size) || size <= 0) {
     throw new Error("size: expected positive integer, but got: " + size);
   }
   if (

--- a/src/core/attribution/markovChain.test.js
+++ b/src/core/attribution/markovChain.test.js
@@ -6,6 +6,7 @@ import {
   sparseMarkovChainAction,
   sparseMarkovChainFromTransitionMatrix,
   uniformDistribution,
+  indicatorDistribution,
   computeDelta,
   type StationaryDistributionResult,
 } from "./markovChain";
@@ -114,8 +115,11 @@ describe("core/attribution/markovChain", () => {
         [0.25, 0, 0.75],
         [0.25, 0.75, 0],
       ]);
+
+      const alpha = 0;
+      const seed = uniformDistribution(chain.length);
       const pi0 = new Float64Array([0.125, 0.375, 0.625]);
-      const pi1 = sparseMarkovChainAction(chain, pi0);
+      const pi1 = sparseMarkovChainAction(chain, seed, alpha, pi0);
       // The expected value is given by `pi0 * A`, where `A` is the
       // transition matrix. In Octave:
       // >> A = [ 1 0 0; 0.25 0 0.75 ; 0.25 0.75 0 ];
@@ -125,6 +129,32 @@ describe("core/attribution/markovChain", () => {
       //    0.37500   0.46875   0.28125
       const expected = new Float64Array([0.375, 0.46875, 0.28125]);
       expect(pi1).toEqual(expected);
+    });
+
+    it("acts properly on a nontrivial chain with seed and non-zero alpha", () => {
+      // Note: this test case uses only real numbers that are exactly
+      // representable as floating point numbers.
+      const chain = sparseMarkovChainFromTransitionMatrix([
+        [1, 0, 0],
+        [0.25, 0, 0.75],
+        [0.25, 0.75, 0],
+      ]);
+
+      const alpha = 0.5;
+      const seed = indicatorDistribution(chain.length, 0);
+      const pi0 = new Float64Array([0.6, 0.2, 0.2]);
+      const pi1 = sparseMarkovChainAction(chain, seed, alpha, pi0);
+      // The expected value is given by `(1-alpha)*pi0 * A + alpha*seed`,
+      // where `A` is the transition matrix. In python3:
+      // >> A = np.matrix([[ 1, 0, 0], [0.25, 0, 0.75], [0.25, 0.75, 0 ]])
+      // >> seed = np.array([1,0,0])
+      // >> alpha = .5
+      // >> pi0 = np.array([ 0.6, 0.2, 0.2 ])
+      // >> pi1 = (1-alpha)*pi0 * A + alpha*seed;
+      // >> print(pi1)
+      //    [[0.85  0.075 0.075]]
+      const expected = new Float64Array([0.85, 0.075, 0.075]);
+      expectAllClose(pi1, expected);
     });
   });
 
@@ -142,13 +172,23 @@ describe("core/attribution/markovChain", () => {
     }
   }
 
-  function expectStationary(chain: SparseMarkovChain, pi: Distribution): void {
-    expectAllClose(sparseMarkovChainAction(chain, pi), pi);
+  function expectStationary(
+    chain: SparseMarkovChain,
+    seed: Distribution,
+    alpha: number,
+    pi: Distribution
+  ): void {
+    expectAllClose(sparseMarkovChainAction(chain, seed, alpha, pi), pi);
   }
 
   describe("findStationaryDistribution", () => {
-    function validateConvegenceDelta(chain, d: StationaryDistributionResult) {
-      const nextPi = sparseMarkovChainAction(chain, d.pi);
+    function validateConvegenceDelta(
+      chain: SparseMarkovChain,
+      seed: Distribution,
+      alpha: number,
+      d: StationaryDistributionResult
+    ) {
+      const nextPi = sparseMarkovChainAction(chain, seed, alpha, d.pi);
       expect(d.convergenceDelta).toEqual(computeDelta(d.pi, nextPi));
     }
 
@@ -158,16 +198,25 @@ describe("core/attribution/markovChain", () => {
         [0.25, 0, 0.75],
         [0.25, 0.75, 0],
       ]);
-      const result = await findStationaryDistribution(chain, {
-        maxIterations: 255,
-        convergenceThreshold: 1e-7,
-        verbose: false,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(chain.length);
+      const initialDistribution = uniformDistribution(chain.length);
+      const result: StationaryDistributionResult = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
       expect(result.convergenceDelta).toBeLessThanOrEqual(1e-7);
-      validateConvegenceDelta(chain, result);
+      validateConvegenceDelta(chain, seed, alpha, result);
 
-      expectStationary(chain, result.pi);
+      expectStationary(chain, seed, alpha, result.pi);
       const expected = new Float64Array([1, 0, 0]);
       expectAllClose(result.pi, expected);
     });
@@ -184,49 +233,271 @@ describe("core/attribution/markovChain", () => {
         [0.5, 0, 0.25, 0, 0.25],
         [0.5, 0.25, 0, 0.25, 0],
       ]);
-      const result = await findStationaryDistribution(chain, {
-        maxIterations: 255,
-        convergenceThreshold: 1e-7,
-        verbose: false,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(chain.length);
+      const initialDistribution = uniformDistribution(chain.length);
+      const result = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
 
       expect(result.convergenceDelta).toBeLessThanOrEqual(1e-7);
-      validateConvegenceDelta(chain, result);
+      validateConvegenceDelta(chain, seed, alpha, result);
 
-      expectStationary(chain, result.pi);
+      expectStationary(chain, seed, alpha, result.pi);
       const expected = new Float64Array([1 / 3, 1 / 6, 1 / 6, 1 / 6, 1 / 6]);
+      expectAllClose(result.pi, expected);
+    });
+
+    it("finds a non-degenerate stationary distribution with seed and non-zero alpha", async () => {
+      // Node 0 is the "center" and also the seed; nodes 1 through 4 are "satellites". A
+      // satellite transitions to the center with probability 0.5, or to a
+      // cyclically adjacent satellite with probability 0.25 each. The
+      // center transitions to a uniformly random satellite.
+      const chain = sparseMarkovChainFromTransitionMatrix([
+        [0, 0.25, 0.25, 0.25, 0.25],
+        [0.5, 0, 0.25, 0, 0.25],
+        [0.5, 0.25, 0, 0.25, 0],
+        [0.5, 0, 0.25, 0, 0.25],
+        [0.5, 0.25, 0, 0.25, 0],
+      ]);
+      const alpha = 0.1;
+      const seed = indicatorDistribution(chain.length, 0);
+      const initialDistribution = uniformDistribution(chain.length);
+      const result = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+
+      expect(result.convergenceDelta).toBeLessThanOrEqual(1e-7);
+      validateConvegenceDelta(chain, seed, alpha, result);
+
+      expectStationary(chain, seed, alpha, result.pi);
+      // determine the expected stationary distribtution via Linear algebra
+      // from python3:
+      // >>A = np.matrix([[0, 0.25, 0.25, 0.25, 0.25],
+      //  [0.5, 0, 0.25, 0, 0.25],
+      //  [0.5, 0.25, 0, 0.25, 0],
+      //  [0.5, 0, 0.25, 0, 0.25],
+      //  [0.5, 0.25, 0, 0.25, 0]])
+      // >>seed = np.array([1, 0, 0, 0, 0])
+      // >>n = len(seed)
+      // >>alpha = .1
+      // >>piStar = alpha * seed * np.linalg.inv(np.eye(n) -(1-alpha)*A)
+      // >>print(piStar)
+
+      const expected = new Float64Array([
+        0.37931034,
+        0.15517241,
+        0.15517241,
+        0.15517241,
+        0.15517241,
+      ]);
       expectAllClose(result.pi, expected);
     });
 
     it("finds the stationary distribution of a periodic chain", async () => {
       const chain = sparseMarkovChainFromTransitionMatrix([[0, 1], [1, 0]]);
-      const result = await findStationaryDistribution(chain, {
-        maxIterations: 255,
-        convergenceThreshold: 1e-7,
-        verbose: false,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(chain.length);
+      const initialDistribution = uniformDistribution(chain.length);
+      const result = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
 
       expect(result.convergenceDelta).toEqual(0);
-      validateConvegenceDelta(chain, result);
+      validateConvegenceDelta(chain, seed, alpha, result);
 
-      expectStationary(chain, result.pi);
+      expectStationary(chain, seed, alpha, result.pi);
       const expected = new Float64Array([0.5, 0.5]);
       expectAllClose(result.pi, expected);
     });
 
     it("returns initial distribution if maxIterations===0", async () => {
       const chain = sparseMarkovChainFromTransitionMatrix([[0, 1], [0, 1]]);
-      const result = await findStationaryDistribution(chain, {
-        verbose: false,
-        convergenceThreshold: 1e-7,
-        maxIterations: 0,
-        yieldAfterMs: 1,
-      });
+      const alpha = 0;
+      const seed = uniformDistribution(chain.length);
+      const initialDistribution = uniformDistribution(chain.length);
+      const result = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          verbose: false,
+          convergenceThreshold: 1e-7,
+          maxIterations: 0,
+          yieldAfterMs: 1,
+        }
+      );
       const expected = new Float64Array([0.5, 0.5]);
       expect(result.pi).toEqual(expected);
-      validateConvegenceDelta(chain, result);
+      validateConvegenceDelta(chain, seed, alpha, result);
+    });
+
+    it("is linear in choice of seed vector", async () => {
+      const chain = sparseMarkovChainFromTransitionMatrix([
+        [0.75, 0.25],
+        [0.5, 0.5],
+      ]);
+      const alpha = 0.1;
+      const seed1 = indicatorDistribution(chain.length, 0);
+      const seed2 = indicatorDistribution(chain.length, 1);
+      const seedUniform = uniformDistribution(chain.length);
+      const initialDistribution = uniformDistribution(chain.length);
+
+      const result1 = await findStationaryDistribution(
+        chain,
+        seed1,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+
+      const result2 = await findStationaryDistribution(
+        chain,
+        seed2,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+      const resultUniform = await findStationaryDistribution(
+        chain,
+        seedUniform,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+
+      function addDistributions(
+        d1: Distribution,
+        d2: Distribution
+      ): Distribution {
+        if (d1.length !== d2.length) {
+          throw new Error("Can't add distributions of different sizes.");
+        }
+        const newDistribution = new Float64Array(d1.length);
+        for (let i = 0; i < newDistribution.length; i++) {
+          newDistribution[i] = d1[i] + d2[i];
+        }
+        return newDistribution;
+      }
+
+      function scaleDistribution(
+        scalar: number,
+        d: Distribution
+      ): Distribution {
+        const newDistribution = new Float64Array(d.length);
+        for (let i = 0; i < newDistribution.length; i++) {
+          newDistribution[i] = scalar * d[i];
+        }
+        return newDistribution;
+      }
+
+      const combined = addDistributions(result1.pi, result2.pi);
+
+      expectAllClose(scaleDistribution(2, resultUniform.pi), combined);
+    });
+
+    it("ignores seed when alpha is zero", async () => {
+      const chain = sparseMarkovChainFromTransitionMatrix([
+        [0.75, 0.25],
+        [0.5, 0.5],
+      ]);
+      const alpha = 0;
+      const seed1 = indicatorDistribution(chain.length, 0);
+      const seed2 = indicatorDistribution(chain.length, 1);
+      const initialDistribution = uniformDistribution(chain.length);
+
+      const result1 = await findStationaryDistribution(
+        chain,
+        seed1,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+      const result2 = await findStationaryDistribution(
+        chain,
+        seed2,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+      expectAllClose(result1.pi, result2.pi);
+    });
+
+    it("returns seed when alpha is one", async () => {
+      const chain = sparseMarkovChainFromTransitionMatrix([
+        [0.75, 0.25],
+        [0.5, 0.5],
+      ]);
+      const alpha = 1;
+      const seed = indicatorDistribution(chain.length, 0);
+      const initialDistribution = uniformDistribution(chain.length);
+
+      const result = await findStationaryDistribution(
+        chain,
+        seed,
+        alpha,
+        initialDistribution,
+        {
+          maxIterations: 255,
+          convergenceThreshold: 1e-7,
+          verbose: false,
+          yieldAfterMs: 1,
+        }
+      );
+      expectAllClose(result.pi, seed);
     });
   });
 });

--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -21,7 +21,10 @@ import {
   createOrderedSparseMarkovChain,
   type EdgeWeight,
 } from "./attribution/graphToMarkovChain";
-import {findStationaryDistribution} from "../core/attribution/markovChain";
+import {
+  findStationaryDistribution,
+  uniformDistribution,
+} from "../core/attribution/markovChain";
 import * as NullUtil from "../util/null";
 
 export {Direction} from "./graph";
@@ -421,12 +424,21 @@ export class PagerankGraph {
       this._syntheticLoopWeight
     );
     const osmc = createOrderedSparseMarkovChain(connections);
-    const distributionResult = await findStationaryDistribution(osmc.chain, {
-      verbose: false,
-      convergenceThreshold: options.convergenceThreshold,
-      maxIterations: options.maxIterations,
-      yieldAfterMs: 30,
-    });
+    const alpha = 0;
+    const seed = uniformDistribution(osmc.chain.length);
+    const initialDistribution = uniformDistribution(osmc.chain.length);
+    const distributionResult = await findStationaryDistribution(
+      osmc.chain,
+      seed,
+      alpha,
+      initialDistribution,
+      {
+        verbose: false,
+        convergenceThreshold: options.convergenceThreshold,
+        maxIterations: options.maxIterations,
+        yieldAfterMs: 30,
+      }
+    );
     this._scores = distributionToNodeDistribution(
       osmc.nodeOrder,
       distributionResult.pi


### PR DESCRIPTION
Summary:
the cred calculation is defined by a Markov Mixing process, by introducing the seed vector and teleportation parameter alpha, the Markov mixing process is augmented with a source of cred originating from the seed vector. The resulting algorithm is the generalized variation of Pagerank, allowing computation of both canonical PageRank where the seed vector is the uniform distribution and personalized PageRank where the seed vector is an indicator distribution. It is still possible to get the simple markov chain solution by setting alpha = 0.

Note that this changes the Markov process state update, but does not provide updates to the APIs. All existing behavior is unchanged because alpha is always set to 0.


Test Plan:

Existing tests have been extended to include passing alpha = 0 to reproduce exisiting test cases for the simple Markov Process. Addition test cases include
 - Verifying that resulting stationary distribution is unaffected by seed when alpha = 0
 - Verifying that resulting stationary distribution is precisely equal to seed when alpha = 1
 - Verifying that the resulting stationary distribution is linear in the seed vector
 - Verifying that the correct stationary distribution is computed for non-zero alpha 

