### PR TITLE
refactor: group Pagerank args as PagerankParams

### DIFF
--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -137,14 +137,17 @@ function sparseMarkovChainActionInto(
   });
 }
 
-export function sparseMarkovChainAction(
-  chain: SparseMarkovChain,
-  seed: Distribution,
-  alpha: number,
-  pi: Distribution
-): Distribution {
-  const result = new Float64Array(pi.length);
-  sparseMarkovChainActionInto(chain, seed, alpha, pi, result);
+export type PagerankParams = {|
+  +chain: SparseMarkovChain,
+  +seed: Distribution,
+  +alpha: number,
+  +pi0: Distribution,
+|};
+
+export function sparseMarkovChainAction(params: PagerankParams): Distribution {
+  const {chain, seed, alpha, pi0} = params;
+  const result = new Float64Array(pi0.length);
+  sparseMarkovChainActionInto(chain, seed, alpha, pi0, result);
   return result;
 }
 
@@ -166,10 +169,7 @@ export function computeDelta(pi0: Distribution, pi1: Distribution) {
 }
 
 function* findStationaryDistributionGenerator(
-  chain: SparseMarkovChain,
-  seed: Distribution,
-  alpha: number,
-  initialDistribution: Distribution,
+  params: PagerankParams,
   options: {|
     +verbose: boolean,
     // A distribution is considered stationary if the action of the Markov
@@ -180,7 +180,8 @@ function* findStationaryDistributionGenerator(
     +maxIterations: number,
   |}
 ): Generator<void, StationaryDistributionResult, void> {
-  let pi = initialDistribution;
+  const {chain, seed, alpha, pi0} = params;
+  let pi = pi0;
   let scratch = new Float64Array(pi.length);
 
   let nIterations = 0;
@@ -224,7 +225,7 @@ export function findStationaryDistribution(
   chain: SparseMarkovChain,
   seed: Distribution,
   alpha: number,
-  initialDistribution: Distribution,
+  pi0: Distribution,
   options: {|
     +verbose: boolean,
     +convergenceThreshold: number,
@@ -233,10 +234,12 @@ export function findStationaryDistribution(
   |}
 ): Promise<StationaryDistributionResult> {
   let gen = findStationaryDistributionGenerator(
-    chain,
-    seed,
-    alpha,
-    initialDistribution,
+    {
+      chain,
+      seed,
+      alpha,
+      pi0,
+    },
     {
       verbose: options.verbose,
       convergenceThreshold: options.convergenceThreshold,

--- a/src/core/attribution/markovChain.test.js
+++ b/src/core/attribution/markovChain.test.js
@@ -130,7 +130,7 @@ describe("core/attribution/markovChain", () => {
       const alpha = 0;
       const seed = uniformDistribution(chain.length);
       const pi0 = new Float64Array([0.125, 0.375, 0.625]);
-      const pi1 = sparseMarkovChainAction(chain, seed, alpha, pi0);
+      const pi1 = sparseMarkovChainAction({chain, seed, alpha, pi0});
       // The expected value is given by `pi0 * A`, where `A` is the
       // transition matrix. In Octave:
       // >> A = [ 1 0 0; 0.25 0 0.75 ; 0.25 0.75 0 ];
@@ -154,7 +154,7 @@ describe("core/attribution/markovChain", () => {
       const alpha = 0.5;
       const seed = indicatorDistribution(chain.length, 0);
       const pi0 = new Float64Array([0.6, 0.2, 0.2]);
-      const pi1 = sparseMarkovChainAction(chain, seed, alpha, pi0);
+      const pi1 = sparseMarkovChainAction({chain, seed, alpha, pi0});
       // The expected value is given by `(1-alpha)*pi0 * A + alpha*seed`,
       // where `A` is the transition matrix. In python3:
       // >> A = np.matrix([[ 1, 0, 0], [0.25, 0, 0.75], [0.25, 0.75, 0 ]])
@@ -187,9 +187,9 @@ describe("core/attribution/markovChain", () => {
     chain: SparseMarkovChain,
     seed: Distribution,
     alpha: number,
-    pi: Distribution
+    pi0: Distribution
   ): void {
-    expectAllClose(sparseMarkovChainAction(chain, seed, alpha, pi), pi);
+    expectAllClose(sparseMarkovChainAction({chain, seed, alpha, pi0}), pi0);
   }
 
   describe("findStationaryDistribution", () => {
@@ -199,7 +199,7 @@ describe("core/attribution/markovChain", () => {
       alpha: number,
       d: StationaryDistributionResult
     ) {
-      const nextPi = sparseMarkovChainAction(chain, seed, alpha, d.pi);
+      const nextPi = sparseMarkovChainAction({chain, seed, alpha, pi0: d.pi});
       expect(d.convergenceDelta).toEqual(computeDelta(d.pi, nextPi));
     }
 


### PR DESCRIPTION
This straightforward refactor switches the core markov chain methods
that implement PageRank from accepting positional arguments to accepting
a named object of arguments. We plan to add additional features to the
PagerankGraph.runPagerank API, and this refactor will make testing those
features easier.

Test plan: Straightforward refactor; `yarn test` passes.

Paired with @mzargham