### PR TITLE
Add entity-level methods for odyssey core

### DIFF
--- a/src/plugins/odyssey/model.js
+++ b/src/plugins/odyssey/model.js
@@ -52,7 +52,7 @@ export class OdysseyInstance {
     this._addressToEntity = new Map();
   }
 
-  _addNode(
+  addEntity(
     name: string,
     description: string,
     type: OdysseyEntityType
@@ -68,21 +68,25 @@ export class OdysseyInstance {
     return e;
   }
 
-  // Returns whether the given name is present in the instance.
-  // If it is, then no node with this name may be added.
-  hasName(name: string): boolean {
-    return this._names.has(name);
-  }
-
   *_entitiesOfPrefix(prefix: NodeAddressT): Iterator<OdysseyEntity> {
     for (const a of this._graph.nodes({prefix})) {
       yield NullUtil.get(this._addressToEntity.get(a));
     }
   }
 
+  entities(): Iterator<OdysseyEntity> {
+    return this._entitiesOfPrefix(NodePrefix.base);
+  }
+
+  // Returns whether the given name is present in the instance.
+  // If it is, then no node with this name may be added.
+  hasName(name: string): boolean {
+    return this._names.has(name);
+  }
+
   // Add a new Priority node. May error if this name was ever used before.
   addPriority(name: string, description: string): OdysseyEntity {
-    return this._addNode(name, description, "PRIORITY");
+    return this.addEntity(name, description, "PRIORITY");
   }
 
   priorities(): Iterator<OdysseyEntity> {
@@ -91,7 +95,7 @@ export class OdysseyInstance {
 
   // Add a new Person node. May error if this name was ever used before.
   addPerson(name: string, description: string): OdysseyEntity {
-    return this._addNode(name, description, "PERSON");
+    return this.addEntity(name, description, "PERSON");
   }
 
   people(): Iterator<OdysseyEntity> {
@@ -100,7 +104,7 @@ export class OdysseyInstance {
 
   // Add a new Contribution node. May error if this name was ever used before.
   addContribution(name: string, description: string): OdysseyEntity {
-    return this._addNode(name, description, "CONTRIBUTION");
+    return this.addEntity(name, description, "CONTRIBUTION");
   }
 
   contributions(): Iterator<OdysseyEntity> {

--- a/src/plugins/odyssey/model.test.js
+++ b/src/plugins/odyssey/model.test.js
@@ -7,33 +7,42 @@ import {EdgeAddress} from "../../core/graph";
 describe("plugins/odyssey/model", () => {
   const example = () => {
     const instance = new OdysseyInstance();
+    const expectedEntities = [];
 
     // Add people
     const me = instance.addPerson("me", "the author of the code");
-    const myPartner = instance.addPerson(
+    expectedEntities.push(me);
+    // You can add an entity using the generic API if you prefer
+    const myPartner = instance.addEntity(
       "my partner",
-      "a wonderful human being"
+      "a wonderful human being",
+      "PERSON"
     );
+    expectedEntities.push(myPartner);
 
     // Add some priorities
     const hackathonPriority = instance.addPriority(
       "hackathon",
       "it's what we're working on"
     );
+    expectedEntities.push(hackathonPriority);
     const testingPriority = instance.addPriority(
       "testing",
       "it's very important"
     );
+    expectedEntities.push(testingPriority);
 
     // Add contributions
     const odysseyModule = instance.addContribution(
       "odyssey/model.js",
       "some nice looking source code"
     );
+    expectedEntities.push(odysseyModule);
     const thisFile = instance.addContribution(
       "odyssey/model.test.js",
       "a very fine test file"
     );
+    expectedEntities.push(thisFile);
 
     // Helper function to make it easy to check the edges
     const expectedEdges = [];
@@ -66,6 +75,7 @@ describe("plugins/odyssey/model", () => {
       thisFile,
       odysseyModule,
       expectedEdges,
+      expectedEntities,
     };
   };
 
@@ -85,6 +95,16 @@ describe("plugins/odyssey/model", () => {
     const {instance, odysseyModule, thisFile} = example();
     const contributions = Array.from(instance.contributions());
     expect(contributions).toEqual([odysseyModule, thisFile]);
+  });
+
+  it("can retrieve all entities", () => {
+    const {instance, expectedEntities} = example();
+    const allEntities = Array.from(instance.entities());
+    expect(allEntities).toHaveLength(expectedEntities.length);
+    for (const entity of expectedEntities) {
+      const index = allEntities.findIndex((x) => deepEqual(x, entity));
+      expect(index).not.toBe(-1);
+    }
   });
 
   it("errors if a name is duplicated (even across types)", () => {


### PR DESCRIPTION
As requested by @BrianLitwin, this commit adds entity level methods for
adding an entity (basically an exposed version of _addNode) and a
corresponding method for iterating over all the entities.

Test plan: `yarn test`